### PR TITLE
removed one equal sign from a code example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ end
 And in your views:
 
 ```erb
-<%= for activity in @activities %>
+<% for activity in @activities %>
   <%= render_activity(activity) %>
 <% end %>
 ```


### PR DESCRIPTION
This is my first Pull Request ever, have a heart! :)

The equal sign in the first line is not needed and causes an error if folks will copy paste the code, as I did! :) So I removed it.

```
<%= for activity in @activities %>
  <%= render_activity(activity, :layout => :activity) %>
<% end %>
```
