### PR TITLE
:only and :except options can now take a single symbol as an argument

### DIFF
--- a/lib/public_activity/roles/tracked.rb
+++ b/lib/public_activity/roles/tracked.rb
@@ -185,7 +185,7 @@ module PublicActivity
       #   Disables recording of activities on create/update/destroy leaving that to programmer's choice. Check {PublicActivity::Common#create_activity}
       #   for a guide on how to manually record activities.
       # [:only]
-      #   Accepts array of symbols, of which correct is any combination of the three:
+      #   Accepts a symbol or an array of symbols, of which any combination of the three is accepted:
       #   * _:create_
       #   * _:update_
       #   * _:destroy_
@@ -196,15 +196,16 @@ module PublicActivity
       #   * _article.create_
       #   * _article.update_
       #   * _article.destroy_
-      #   Since only three options are valid in this array,
+      #   Since only three options are valid,
       #   see _:except_ option for a shorter version
       # [:except]
-      #   Accepts array of symbols with values like in _:only_, above.
+      #   Accepts a symbol or an array of symbols with values like in _:only_, above.
       #   Values provided will be subtracted from all default actions:
       #   (create, update, destroy).
       #
       #   So, passing _create_ would track and automatically create
-      #   activities on _update_ and _destroy_ actions.
+      #   activities on _update_ and _destroy_ actions,
+      #   but not on the _create_ action.
       # [:on]
       #   Accepts a Hash with key being the *action* on which to execute *value* (proc)
       #   Currently supported only for CRUD actions which are enabled in _:only_
@@ -235,12 +236,12 @@ module PublicActivity
           include Update
         end
 
-        if options[:except].is_a? Array
-          options[:only] = all_options - options[:except]
+        if options[:except]
+          options[:only] = all_options - Array(options[:except])
         end
 
-        if options[:only].is_a? Array
-          options[:only].each do |opt|
+        if options[:only]
+          Array(options[:only]).each do |opt|
             if opt.eql?(:create)
               include Creation
             elsif opt.eql?(:destroy)

--- a/test/test_tracking.rb
+++ b/test/test_tracking.rb
@@ -121,7 +121,7 @@ describe PublicActivity::Tracked do
       end.wont_be_empty }
     end
 
-    it 'accepts :except option' do
+    it 'accepts :except option with an array of symbols' do
       options = {:except => [:create]}
       subject.tracked(options)
       options[:only].wont_include :create
@@ -133,13 +133,34 @@ describe PublicActivity::Tracked do
       subject.must_include PublicActivity::Destruction
     end
 
-    it 'accepts :only option' do
+    it 'accepts :except option with a single symbol' do
+      options = {:except => :create}
+      subject.tracked(options)
+      options[:only].wont_include :create
+      options[:only].must_include :update
+      options[:only].must_include :destroy
+
+      subject.wont_include PublicActivity::Creation
+      subject.must_include PublicActivity::Update
+      subject.must_include PublicActivity::Destruction
+    end
+
+    it 'accepts :only option with an array of symbols' do
       options = {:only => [:create, :update]}
       subject.tracked(options)
       subject.must_include PublicActivity::Common
       subject.must_include PublicActivity::Creation
       subject.wont_include PublicActivity::Destruction
       subject.must_include PublicActivity::Update
+    end
+
+    it 'accepts :only option with a single symbol' do
+      options = {:only => :create}
+      subject.tracked(options)
+      subject.must_include PublicActivity::Common
+      subject.must_include PublicActivity::Creation
+      subject.wont_include PublicActivity::Destruction
+      subject.wont_include PublicActivity::Update
     end
 
     it 'accepts :owner option' do


### PR DESCRIPTION
This is a really small patch so you can use the `:only` and `:except` options with a symbol like you can in the `routes.rb` file:

```
resources :users, only: :show
```

I had some trouble running the tests because of the `001_create_activities.rb` file. I got this error:

```
C:/Ruby193/lib/ruby/gems/1.9.1/gems/activesupport-3.2.9/lib/active_support/dependencies.rb:251:in `require': C:/.../public_activity/test/migrations/001_create_activities.rb:1: syntax error, unexpected tDOT2 (SyntaxError)
../../lib/generators/public_activity/migration/templates/migration.rb
  ^
C:/.../public_activity/test/migrations/001_create_activities.rb:1: unknown regexp options - lb
  from C:/Ruby193/lib/ruby/gems/1.9.1/gems/activesupport-3.2.9/lib/active_support/dependencies.rb:251:in `block in require'
  from C:/Ruby193/lib/ruby/gems/1.9.1/gems/activesupport-3.2.9/lib/active_support/dependencies.rb:236:in `load_dependency'
  from C:/Ruby193/lib/ruby/gems/1.9.1/gems/activesupport-3.2.9/lib/active_support/dependencies.rb:251:in `require'
  from C:/Ruby193/lib/ruby/gems/1.9.1/gems/activerecord-3.2.9/lib/active_record/migration.rb:537:in `load_migration'
  from C:/Ruby193/lib/ruby/gems/1.9.1/gems/activerecord-3.2.9/lib/active_record/migration.rb:533:in `migration'
  from C:in `migrate'
  from C:/Ruby193/lib/ruby/gems/1.9.1/gems/activerecord-3.2.9/lib/active_record/migration.rb:720:in `block (2 levels) in migrate'
```

I tried to fix it but I just couldn't find a way to do it. So I simply solved the problem by copying the contents of the migration located in `/lib/generators/public_activity/migration/templates/migration.rb` into the `001_create_activities.rb`. The tests then passed so I also added 2 more tests to test this patch.

This is the first time I send a pull request so bear with me. I noticed you have several branches but I didn't know where to send the pull request so I just left it to the default master branch. If there's anything I can do to make this better, please say it.
