### PR TITLE
Add _id,_type index pairs to activities table for improved query times

### DIFF
--- a/lib/generators/public_activity/migration/templates/migration.rb
+++ b/lib/generators/public_activity/migration/templates/migration.rb
@@ -11,6 +11,10 @@ class CreateActivities < ActiveRecord::Migration
 
       t.timestamps
     end
+
+    add_index :activities, [:trackable_id, :trackable_type]
+    add_index :activities, [:owner_id, :owner_type]
+    add_index :activities, [:recipient_id, :recipient_type]
   end
   # Drop table
   def self.down


### PR DESCRIPTION
In order to improve query times for accessing activity from various associations, I've added indexes to each of the polymorphic association column pairs on the activities table.
