### PR TITLE
corrected owner key name

### DIFF
--- a/lib/public_activity/common.rb
+++ b/lib/public_activity/common.rb
@@ -273,7 +273,7 @@ module PublicActivity
       all_options = args.extract_options!
       options = {
         key: all_options.delete(:key),
-        owner: all_options.delete(:key),
+        owner: all_options.delete(:owner),
         action: all_options.delete(:action),
         recipient: all_options.delete(:recipient),
         parameters: all_options.delete(:parameters) || all_options.delete(:params)


### PR DESCRIPTION
Resolves pokonski/public_activity#67 by fixing the key name (`:owner`).
