### PR TITLE
Create named scope "sorted", which sorts records from db

### DIFF
--- a/lib/public_activity/orm/active_record/activity.rb
+++ b/lib/public_activity/orm/active_record/activity.rb
@@ -18,7 +18,7 @@ module PublicActivity
         # should recipient and owner be accessible?
         attr_accessible :key, :owner, :parameters, :recipient, :trackable
 
-        default_scope :order => "#{quoted_table_name}.created_at DESC"
+        scope :sorted, lambda { :order => "#{quoted_table_name}.created_at DESC" }
       end
     end
   end

--- a/lib/public_activity/orm/mongoid/activity.rb
+++ b/lib/public_activity/orm/mongoid/activity.rb
@@ -20,7 +20,7 @@ module PublicActivity
         field :key,         type: String
         field :parameters,  type: Hash
 
-        default_scope desc(:created_at)
+        scope :sorted, lambda { desc(:created_at) }
       end
     end
   end


### PR DESCRIPTION
It's good if you don't know what is a PublicActivity::Activity class.
Class PublicActivity::Activity can be ActiveRecord::Base or Mongoid Document, so it's good to use one method "sorted":

``` ruby
PublicActivity::Activity.sorted.includes(:owner, :trackable, :recipient)
```

This code works in both orm's.
