### PR TITLE
Prevent #prepare_settings from changing global custom fields

### DIFF
--- a/lib/public_activity/common.rb
+++ b/lib/public_activity/common.rb
@@ -308,7 +308,7 @@ module PublicActivity
       options[:parameters] = params
       options.delete(:params)
 
-      customs = self.class.activity_custom_fields_global
+      customs = self.class.activity_custom_fields_global.clone
       customs.merge!(self.activity_custom_fields) if self.activity_custom_fields
       customs.merge!(all_options)
       customs.each do  |k, v|

--- a/test/test_tracking.rb
+++ b/test/test_tracking.rb
@@ -108,6 +108,13 @@ describe PublicActivity::Tracked do
     a.activities.count.must_equal 1
   end
 
+  it 'should not change global custom fields' do
+    a = article(nonstandard: 'global').new
+    a.activity nonstandard: 'instance'
+    a.save
+    a.class.activity_custom_fields_global.must_equal nonstandard: 'global'
+  end
+
   describe 'disabling functionality' do
     it 'allows for global disable' do
       PublicActivity.enabled = false


### PR DESCRIPTION
This pull request fixes a bug that changes global custom fields when setting custom fields on instance and save it to create activity.

``` irb
>> Article.activity_custom_fields_global
=> {:nonstandard => 'global'}
>> art = Article.new
>> art.activity :nonstandard => 'instance'
>> art.save
>> Article.activity_custom_fields_global
=> {:nonstandard => 'instance'}
```

That is because in `#prepare_settings`, instance custom fields are merged to local variable which references global custom fields without cloning it first.
