### PR TITLE
activity#render passes all params to view context

### DIFF
--- a/lib/public_activity/renderable.rb
+++ b/lib/public_activity/renderable.rb
@@ -94,13 +94,13 @@ module PublicActivity
       params_indifferent = self.parameters.with_indifferent_access
       params_indifferent.merge!(params)
 
-      context.render :partial => (partial_path || self.template_path(self.key)),
+      context.render params.merge(:partial => (partial_path || self.template_path(self.key)),
         :layout => layout,
         :locals => locals.merge(:a => self, :activity => self,
            :controller => controller,
            :current_user => controller.respond_to?(:current_user) ?
                 controller.current_user : nil ,
-           :p => params_indifferent, :params => params_indifferent)
+           :p => params_indifferent, :params => params_indifferent))
     end
 
     protected

--- a/test/test_activity.rb
+++ b/test/test_activity.rb
@@ -52,6 +52,13 @@ describe 'PublicActivity::Activity Rendering' do
       rendered.must_equal '1 2'
     end
 
+    it "pass all params to view context" do
+      view_context = mock('ViewContext')
+      PublicActivity.set_controller(nil)
+      view_context.expects(:render).with() {|params| params[:formats] == ['json']}
+      subject.render(view_context, :formats => ['json'])
+    end
+
     it "uses specified layout" do
       PublicActivity.set_controller(nil)
       subject.render(self, :layout => "activity")


### PR DESCRIPTION
do not limit params passed to view context via render. Currently it is impossible to pass i.e. `formats: ['json']`.
See those tests for details: 
https://github.com/rails/rails/blob/b5e851e90bd1382fa1875d0a9fb2f997b817c25e/actionview/test/template/render_test.rb#L32

with this p/r P_A forwards everything as is unless explicitly modified.
