### PR TITLE
Allow specifying template and partial locations.

### DIFF
--- a/test/test_activity.rb
+++ b/test/test_activity.rb
@@ -70,5 +70,18 @@ describe 'PublicActivity::Activity Rendering' do
       subject.render(self, :layout => :activity)
       rendered.must_include "Here be the layouts"
     end
+
+    it "accepts a custom layout root" do
+      subject.render(self, :layout => :layout, :layout_root => "custom")
+      rendered.must_include "Here be the custom layouts"
+    end
+    it "accepts an absolute layout path" do
+      subject.render(self, :layout => '/custom/layout')
+      rendered.must_include "Here be the custom layouts"
+    end
+    it "accepts a template root" do
+      subject.render(self, :root => "custom")
+      rendered.must_include "Custom Template Root"
+    end
   end
 end

--- a/test/views/custom/_layout.erb
+++ b/test/views/custom/_layout.erb
@@ -1,0 +1,1 @@
+<h2>Here be the custom layouts</h2><%= yield %>

--- a/test/views/custom/_test.erb
+++ b/test/views/custom/_test.erb
@@ -1,0 +1,1 @@
+Custom Template Root <%= activity.id %>


### PR DESCRIPTION
This change allows for more than one rendering of an activity (list.)

example:

``` ruby
  # Large, interactive rendering
  = render_activities(@activities, :root => "/profile/activity", :layout => "/profile/activity/layout")

  # Small, terse rendering
  = render_activities(@activities, :root => "/sidebar/activity", :layout => "/profile/sidebar/layout")
```
