### PR TITLE
prepare_locals: Use Object#send instead of calling directly.

### DIFF
--- a/lib/public_activity/renderable.rb
+++ b/lib/public_activity/renderable.rb
@@ -129,7 +129,7 @@ module PublicActivity
           :a              => self,
           :activity       => self,
           :controller     => controller,
-          :current_user   => controller.respond_to?(:current_user) ? controller.current_user : nil,
+          :current_user   => controller.respond_to?(:current_user) ? controller.send(:current_user) : nil,
           :p              => prepared_params,
           :params         => prepared_params
         }


### PR DESCRIPTION
Object#respond_to? will return true for protected methods. However
calling a protected method directly results in an exception. Using
Object#send allows a protected method (like current_user) to be
called.
