### PR TITLE
`render_activities` -> nil when list is empty

### DIFF
--- a/lib/public_activity/utility/view_helpers.rb
+++ b/lib/public_activity/utility/view_helpers.rb
@@ -7,6 +7,7 @@ module PublicActivity
       if activities.is_a? PublicActivity::Activity
         activities.render self, options
       elsif activities.respond_to?(:map)
+        return nil if activities.empty?
         # depend on ORMs to fetch as needed
         # maybe we can support Postgres streaming with this?
         activities.map {|activity| activity.render self, options.dup }.join.html_safe

--- a/test/test_view_helpers.rb
+++ b/test/test_view_helpers.rb
@@ -17,6 +17,10 @@ describe 'ViewHelpers Rendering' do
     render_activities([activity])
   end
 
+  it 'returns false when given an empty list' do
+    render_activities([]).must_equal nil
+  end
+
   it 'flushes content_for between partials renderes' do
     @view_flow = mock('view_flow')
     @view_flow.expects(:set).twice.with('name', ActiveSupport::SafeBuffer.new)


### PR DESCRIPTION
Allows usage in the form:

```
render_activities(@activities) || 'There are no activities'
```
