### PR TITLE
Add extension .rb to the migration generated files

### DIFF
--- a/lib/generators/public_activity/migration/migration_generator.rb
+++ b/lib/generators/public_activity/migration/migration_generator.rb
@@ -10,7 +10,7 @@ module PublicActivity
       argument :name, :type => :string, :default => 'create_activities'
       # Create migration in project's folder
       def generate_files
-        migration_template 'migration.rb', "db/migrate/#{name}"
+        migration_template 'migration.rb', "db/migrate/#{name}.rb"
       end
     end
   end

--- a/lib/generators/public_activity/migration_upgrade/migration_upgrade_generator.rb
+++ b/lib/generators/public_activity/migration_upgrade/migration_upgrade_generator.rb
@@ -10,7 +10,7 @@ module PublicActivity
       argument :name, :type => :string, :default => 'upgrade_activities'
       # Create migration in project's folder
       def generate_files
-        migration_template 'upgrade.rb', "db/migrate/#{name}"
+        migration_template 'upgrade.rb', "db/migrate/#{name}.rb"
       end
     end
   end


### PR DESCRIPTION
This empeded the migration to be launched properly.
rake db:migrate wasn't doing anything
