### PR TITLE
Allow customizing the model name

### DIFF
--- a/lib/public_activity/config.rb
+++ b/lib/public_activity/config.rb
@@ -3,12 +3,13 @@ require 'singleton'
 module PublicActivity
   # Class used to initialize configuration object.
   class Config
-    attr_accessor :enabled, :table_name
+    attr_accessor :enabled, :table_name, :model_name
     attr_reader :orm
 
     def initialize
       @enabled    = true
       @table_name = "activities"
+      @model_name = "::PublicActivity::Activity"
       @orm        = :active_record
     end
 

--- a/lib/public_activity/orm/active_record/activist.rb
+++ b/lib/public_activity/orm/active_record/activist.rb
@@ -23,10 +23,10 @@ module PublicActivity
         #
         def activist
           has_many :activities_as_owner,
-            :class_name => "::PublicActivity::Activity",
+            :class_name => PublicActivity.config.model_name,
             :as => :owner
           has_many :activities_as_recipient,
-            :class_name => "::PublicActivity::Activity",
+            :class_name => PublicActivity.config.model_name,
             :as => :recipient
         end
       end

--- a/lib/public_activity/orm/active_record/trackable.rb
+++ b/lib/public_activity/orm/active_record/trackable.rb
@@ -7,7 +7,7 @@ module PublicActivity
         # Creates an association for activities where self is the *trackable*
         # object.
         def self.extended(base)
-          base.has_many :activities, :class_name => "::PublicActivity::Activity", :as => :trackable
+          base.has_many :activities, :class_name => PublicActivity.config.model_name, :as => :trackable
         end
       end
     end

--- a/lib/public_activity/orm/mongo_mapper/activist.rb
+++ b/lib/public_activity/orm/mongo_mapper/activist.rb
@@ -22,10 +22,10 @@ module PublicActivity
         #
         def activist
           many :activities_as_owner,
-            :class_name => "::PublicActivity::Activity",
+            :class_name => PublicActivity.config.model_name,
             :as => :owner
           many :activities_as_recipient,
-            :class_name => "::PublicActivity::Activity",
+            :class_name => PublicActivity.config.model_name,
             :as => :recipient
         end
       end

--- a/lib/public_activity/orm/mongo_mapper/trackable.rb
+++ b/lib/public_activity/orm/mongo_mapper/trackable.rb
@@ -3,7 +3,7 @@ module PublicActivity
     module MongoMapper
       module Trackable
         def self.extended(base)
-          base.many :activities, :class_name => "::PublicActivity::Activity", order: :created_at.asc, :as => :trackable
+          base.many :activities, :class_name => PublicActivity.config.model_name, order: :created_at.asc, :as => :trackable
         end
       end
     end

--- a/lib/public_activity/orm/mongoid/activist.rb
+++ b/lib/public_activity/orm/mongoid/activist.rb
@@ -21,11 +21,11 @@ module PublicActivity
         #
         def activist
           has_many :activities_as_owner,
-            :class_name => "::PublicActivity::Activity",
+            :class_name => PublicActivity.config.model_name,
             :inverse_of => :owner
 
           has_many :activities_as_recipient,
-            :class_name => "::PublicActivity::Activity",
+            :class_name => PublicActivity.config.model_name,
             :inverse_of => :recipient
         end
       end

--- a/lib/public_activity/orm/mongoid/trackable.rb
+++ b/lib/public_activity/orm/mongoid/trackable.rb
@@ -3,7 +3,7 @@ module PublicActivity
     module Mongoid
       module Trackable
         def self.extended(base)
-          base.has_many :activities, :class_name => "::PublicActivity::Activity", :as => :trackable
+          base.has_many :activities, :class_name => PublicActivity.config.model_name, :as => :trackable
         end
       end
     end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -20,5 +20,16 @@ describe PublicActivity do
         config.table_name = "activities"
       end
     end
+
+    it "allows configuring the name of the AR model" do
+      PublicActivity.configure do |config|
+        config.model_name = "ZomgActivitos"
+      end
+      PublicActivity.config.model_name.must_equal "ZomgActivitos"
+
+      PublicActivity.configure do |config|
+        config.model_name = "::PublicActivity::Activity"
+      end
+    end
   end
 end


### PR DESCRIPTION
The `Activity` model comes from the gem, which means it's not very convenient to customize. I'd rather have a domain model in my app that I can extend. It's still somewhat possible to plug custom extensions with an initializer that monkey-patches the `::PublicActivity::Activity` class, but this doesn't work well with autoloading and it has to be placed in a different location than all other models.

The change needed to support this is actually quite simple, the string `::PublicActivity::Activity` is replaced with a config option. This should provide perfect backwards compatibility and a new hook to plug in your own class (in my case, `class ::Activity < ::PublicActivity::Activity`) that is a full-fledged AR model, owned by the app.

Let me know if you'd like me to add more tests or documentation, I wasn't sure how far I should go in that direction.
