### PR TITLE
Fixes Ruby 2.7 warnings

### DIFF
--- a/lib/public_activity/orm/active_record/activity.rb
+++ b/lib/public_activity/orm/active_record/activity.rb
@@ -49,9 +49,9 @@ module PublicActivity
           else
             warn("[WARN] table #{name} doesn't exist. Skipping PublicActivity::Activity#parameters's serialization")
           end
-        rescue ::ActiveRecord::NoDatabaseError => e
+        rescue ::ActiveRecord::NoDatabaseError
           warn("[WARN] database doesn't exist. Skipping PublicActivity::Activity#parameters's serialization")
-        rescue ::PG::ConnectionBad => e
+        rescue ::PG::ConnectionBad
           warn("[WARN] couldn't connect to database. Skipping PublicActivity::Activity#parameters's serialization")
         rescue Mysql2::Error::ConnectionError
           warn("[WARN] couldn't connect to database. Skipping PublicActivity::Activity#parameters's serialization")

--- a/lib/public_activity/renderable.rb
+++ b/lib/public_activity/renderable.rb
@@ -12,7 +12,8 @@ module PublicActivity
       k.unshift('activity') if k.first != 'activity'
       k = k.join('.')
 
-      I18n.t(k, parameters.merge(params) || {})
+      translate_params = parameters.merge(params) || {}	
+      I18n.t(k, **translate_params)
     end
 
     # Renders activity from views.


### PR DESCRIPTION
Fixes ruby warning about unused variables 'e' and needing the double splat operator when passing hashes to i18n.t