### PR TITLE
fixup passing params to I18n.translate

### DIFF
--- a/lib/public_activity/renderable.rb
+++ b/lib/public_activity/renderable.rb
@@ -12,7 +12,7 @@ module PublicActivity
       k.unshift('activity') if k.first != 'activity'
       k = k.join('.')
 
-      I18n.t(k, parameters.merge(params) || {})
+      I18n.t(k, parameters.symbolize_keys.merge(params) || {})
     end
 
     # Renders activity from views.


### PR DESCRIPTION
I18n.translate uses a double splat operator to accept extra parameters
https://github.com/ruby-i18n/i18n/blob/3d0f144038eebe3ff6bc7699de00736abd5ef634/lib/i18n.rb#L196

the double splat operator does not work when the keys are strings

e.g.

```
def printit(**stuff)
   puts stuff.to_a.join(", ")
end

printit(a: 1, b: 2)
#=> a, 1, b, 2

printit("a" => 1, "b" => 2)
#=> wrong number of arguments (given 1, expected 0)
```

`activity.parameters` returns a hash with string keys

so `activity.text` currently raises a `wrong number of arguments` error if the activity has any parameters present

to resolve this, change the keys to symbols