### PR TITLE
Fix regression in generated migration

### DIFF
--- a/lib/generators/public_activity/migration/templates/migration.rb
+++ b/lib/generators/public_activity/migration/templates/migration.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require 'migrations_base'
-
 # Migration responsible for creating a table with activities
-class CreateActivities < MigrationsBase
+class CreateActivities < (ActiveRecord.version.release() < Gem::Version.new('5.2.0') ? ActiveRecord::Migration : ActiveRecord::Migration[5.2])
   def self.up
     create_table :activities do |t|
       t.belongs_to :trackable, :polymorphic => true


### PR DESCRIPTION
It seems that a recent update has added a test-specific base class `MigrationsBase` to the generated migration. This results in `LoadError: cannot load such file -- migrations_base` when running the freshly generated migration. 

This reverses the migration to its previous implementation resulting in a successful migration after installation.

Let me know if I'm missing something here :)