### PR TITLE
Rescue from ActiveRecord::ConnectionNotEstablished

### DIFF
--- a/lib/public_activity/orm/active_record/activity.rb
+++ b/lib/public_activity/orm/active_record/activity.rb
@@ -14,7 +14,7 @@ module PublicActivity
       end
     end
   end
-  
+
   module ORM
     module ActiveRecord
       # The ActiveRecord model containing
@@ -53,6 +53,8 @@ module PublicActivity
           end
         rescue ::ActiveRecord::NoDatabaseError
           warn("[WARN] database doesn't exist. Skipping PublicActivity::Activity#parameters's serialization")
+        rescue ::ActiveRecord::ConnectionNotEstablished
+          warn("[WARN] couldn't connect to database. Skipping PublicActivity::Activity#parameters's serialization")
         rescue ::PG::ConnectionBad
           warn("[WARN] couldn't connect to database. Skipping PublicActivity::Activity#parameters's serialization")
         rescue Mysql2::Error::ConnectionError


### PR DESCRIPTION
Found this commit by @Judahmeek ref'd in comments on public-activity/public_activity#351 and thought why not just get the PR rolling. I hope this helps, @ur5us! I've confirmed this commit at least allows asset pre-compilation in Rails without bombing due to missing database(s). 