### PR TITLE
Mongoid - Activity relations optional support

### DIFF
--- a/lib/public_activity/orm/mongoid/activity.rb
+++ b/lib/public_activity/orm/mongoid/activity.rb
@@ -14,7 +14,7 @@ module PublicActivity
         include Renderable
 
         if ::Mongoid::VERSION.split('.')[0].to_i >= 7
-          opts = { polymorphic: true, optional: false }
+          opts = { polymorphic: true, optional: true }
         else
           opts = { polymorphic: true }
         end


### PR DESCRIPTION
With this change to optional in mongoid 7 and above support has been added by this commit https://github.com/public-activity/public_activity/commit/debdd74c6e82f55ab3f196419c53ee5c78f87b8a. But the test has optional as true but the actual code has optional as false. This is makinng upgrading to the latest version for this gem not feasible with newer mongoid version 7 and 8.