### PR TITLE
Removes duplicate indexes from activities migration template

### DIFF
--- a/lib/generators/public_activity/migration/templates/migration.rb
+++ b/lib/generators/public_activity/migration/templates/migration.rb
@@ -12,10 +12,6 @@ class CreateActivities < ActiveRecord::Migration[5.0]
 
       t.timestamps
     end
-
-    add_index :activities, %i[trackable_id trackable_type]
-    add_index :activities, %i[owner_id owner_type]
-    add_index :activities, %i[recipient_id recipient_type]
   end
 
   # Drop table


### PR DESCRIPTION
I noticed in my app that I had duplicate indexes. As of https://github.com/rails/rails/pull/23179, using `belongs_to` or `references` automatically adds an index. #64 previously manually added the indexes, but they are no longer needed.