### PR TITLE
Fix serialize method for Rails 7.1.2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ recorded activities to users - similarly to how GitHub does it.
 
 ## Rails 7
 
-**As of version 2.0.0, public_activity also supports Rails up to 7.1.2**
+**As of version 2.0.0, public_activity also supports Rails up to 7.0.**
 
 ## Table of contents
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ recorded activities to users - similarly to how GitHub does it.
 
 ## Rails 7
 
-FORK UPDATED 7.1.2
-
 **As of version 2.0.0, public_activity also supports Rails up to 7.1.2**
 
 ## Table of contents

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ recorded activities to users - similarly to how GitHub does it.
 
 ## Rails 7
 
-**As of version 2.0.0, public_activity also supports Rails up to 7.0.**
+FORK UPDATED 7.1.2
+
+**As of version 2.0.0, public_activity also supports Rails up to 7.1.2**
 
 ## Table of contents
 

--- a/lib/public_activity/orm/active_record/activity.rb
+++ b/lib/public_activity/orm/active_record/activity.rb
@@ -39,7 +39,7 @@ module PublicActivity
         # Serialize parameters Hash
         begin
           if table_exists?
-            serialize :parameters, Hash unless %i[json jsonb hstore].include?(columns_hash['parameters'].type)
+            serialize :parameters, coder: YAML, type: Hash unless %i[json jsonb hstore].include?(columns_hash['parameters'].type)
           else
             warn("[WARN] table #{name} doesn't exist. Skipping PublicActivity::Activity#parameters's serialization")
           end


### PR DESCRIPTION
Fix `serialize` method for Rails 7.1.2 compatibility

This commit resolves the `ArgumentError: missing keyword: :coder` issue encountered in Rails 7.1.2. It updates the `serialize` method in `public_activity` gem to include a default coder, ensuring compatibility with the newer Rails version. This change maintains backward compatibility with earlier versions of Rails.
