### PR TITLE
Refactor prepare_parameters method to handle nil parameters

### DIFF
--- a/lib/public_activity/renderable.rb
+++ b/lib/public_activity/renderable.rb
@@ -151,7 +151,11 @@ module PublicActivity
     end
 
     def prepare_parameters(params)
-      @prepared_params ||= self.parameters.with_indifferent_access.merge(params)
+      if self.parameters
+        @prepared_params ||= self.parameters.with_indifferent_access.merge(params)
+      else
+        @prepared_params ||= params
+      end
     end
 
     protected


### PR DESCRIPTION
This pull request fixes an issue in the `prepare_parameters` method where it was trying to call `with_indifferent_access` on `nil`.

The `prepare_parameters` method is used to prepare the parameters for rendering an activity. However, if an activity has `nil` parameters, this method would raise a `NoMethodError: undefined method 'with_indifferent_access' for nil:NilClass` error.

This pull request adds a check to ensure that `self.parameters` is not `nil` before calling `with_indifferent_access` on it. This prevents the `NoMethodError` from being raised and allows activities with `nil` parameters to be rendered correctly.