### PR TITLE
Pin sqlite3 version to 1.*

### DIFF
--- a/public_activity.gemspec
+++ b/public_activity.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'redcarpet'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'sqlite3', '>= 1.4.1'
+  s.add_development_dependency 'sqlite3', '~> 1.4'
   s.add_development_dependency 'test-unit'
   s.add_development_dependency 'yard'
 end


### PR DESCRIPTION
This commit addresses the CI failure.

It is Rails 7.2 that allows sqlite3 version 2.0. Previous versions of Rails are conventionally configured to require sqlite3 "~> 1.4" (meaning it excludes 2.*), which the development dependency can naturally follow.

cf.
https://github.com/rails/rails/blob/v7.1.3.4/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L14

This stops "bundle exec rake" from causing such failure like this, copied from GitHub Action's log:

```
>> BUNDLE_GEMFILE=/home/runner/work/public_activity/public_activity/gemfiles/rails_7.1.gemfile bundle exec rake
/opt/hostedtoolcache/Ruby/3.3.1/x64/lib/ruby/3.3.0/bundler/rubygems_integration.rb:237:in `block (2 levels) in replace_gem': can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.1-x86_64-linux-gnu. Make sure all dependencies are added to Gemfile. (Gem::LoadError)
	from /opt/hostedtoolcache/Ruby/3.3.1/x64/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.3/lib/active_record/connection_adapters/sqlite3_adapter.rb:14:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.3.1/x64/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /opt/hostedtoolcache/Ruby/3.3.1/x64/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/runner/work/public_activity/public_activity/test/test_helper.rb:26:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.3.1/x64/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /opt/hostedtoolcache/Ruby/3.3.1/x64/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/runner/work/public_activity/public_activity/test/test_activist.rb:3:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.3.1/x64/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /opt/hostedtoolcache/Ruby/3.3.1/x64/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /opt/hostedtoolcache/Ruby/3.3.1/x64/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:21:in `block in <main>'
	from /opt/hostedtoolcache/Ruby/3.3.1/x64/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:6:in `select'
	from /opt/hostedtoolcache/Ruby/3.3.1/x64/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:6:in `<main>'
rake aborted!
Command failed with status (1)
/opt/hostedtoolcache/Ruby/3.3.1/x64/bin/bundle:25:in `load'
/opt/hostedtoolcache/Ruby/3.3.1/x64/bin/bundle:25:in `<main>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
Error: Process completed with exit code 1.
```

Source: https://github.com/public-activity/public_activity/actions/runs/9204987054/job/25319683065