### PR TITLE
Introduce Common#activity_key_prefix to allow key customization. (In support of STI)

### DIFF
--- a/lib/public_activity/common.rb
+++ b/lib/public_activity/common.rb
@@ -336,6 +336,14 @@ module PublicActivity
       )
     end
 
+    # Determines the prefix of activity keys
+    # when only an :action is provided.
+    # @see #prepare_key
+    # @return [String] the prefix for new activity keys.
+    def activity_key_prefix
+      self.class.name
+    end
+
     # Helper method to serialize class name into relevant key
     # @return [String] the resulted key
     # @param [Symbol] or [String] the name of the operation to be done on class
@@ -344,7 +352,7 @@ module PublicActivity
       (
         options[:key] ||
         activity_key ||
-        ((self.class.name.underscore.gsub('/', '_') + "." + action.to_s) if action)
+        ((activity_key_prefix.underscore.gsub('/', '_') + '.' + action.to_s) if action)
       ).try(:to_s)
     end
 

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -136,10 +136,19 @@ describe PublicActivity::Common do
         assert_equal @article.prepare_key(:create, {}), 'my_custom_key'
       end
 
-      it 'assigns key based on class name as fallback' do
+      it 'assigns key based on class name as default fallback' do
         def @article.activity_key; nil end
 
         assert_equal @article.prepare_key(:create), 'article.create'
+      end
+
+      it 'assigns key based on activity_key_prefix as fallback' do
+        class PrefixKey < article(owner: :user)
+          def activity_key_prefix; 'MyPrefix' end
+        end
+        @article = PrefixKey.new
+
+        assert_equal @article.prepare_key(:create), 'my_prefix.create'
       end
 
       it 'assigns key value from options hash' do


### PR DESCRIPTION
## What?
This PR introduces the `activity_key_prefix` method in `PublicActivity::Common`.

This method returns `self.class.name` by default. The result of this method is used to determine the prefix of activity keys when only an action is provided to `create_activity`. Example usage below.

```ruby
class Default < AppModel
  tracked
end

Default.new.create_activity(:foo) # => The activity key is 'default.foo'
```
```ruby
class Customized < AppModel
  tracked
  def activity_key_prefix
    'My Custom Key'
  end
end

Customized.new.create_activity(:foo) # => The activity key is 'my_custom_key.foo'
```

## Why?
This change is in support of using single table inheritance. This is not a generalized approach to supporting STI, but it provides a mechanism for users to obtain the behavior necessary for maintaining the same trackable_type, key structure and association queries for parent and child classes.

Below is a demonstration of the current issue preventing simple STI usage and the ability to resolve the issue by overriding `activity_key_prefix`.

With these models:
```ruby
class Animal < ActiveRecord::Base
  include PublicActivity::Model
  tracked
end

class Dog < Animal
end
```
The current behavior is:
```ruby
Animal.new.create_activity(:foo) # => 
# activity.trackable_type = 'Animal'                      ✅
#            activity.key = 'animal.foo'                  ✅
# animal.activities queries for trackable_type = 'Animal' ✅


Dog.new.create_activity(:foo) # => 
# activity.trackable_type = 'Animal'                         ✅
#            activity.key = 'dog.foo'                        ❌
# animal.activities queries for trackable_type = 'Animal'    ✅
```

Notice that the activity key is inconsistent with the `trackable_type` and association. Ideally a generalized solution would exist to support STI in this way, but changing the default behavior would likely break existing implementations somewhere. The ideal approach would be to scan up the ancestry tree to find the ancestor that directly included public activity and use that class name. In the meantime, this PR simple provides a mechanism to implement this behavior on a per-model basis. Like so:

```ruby
class Animal < ActiveRecord::Base
  include PublicActivity::Model
  tracked

  def activity_prefix_key
    Animal.name
  end
end


# Now:

Dog.new.create_activity(:foo) # activity.trackable_type = 'Animal'                      ✅
                              #            activity.key = 'animal.foo'                  ✅
                              # animal.activities queries for trackable_type = 'Animal' ✅
```

I realize that my desired STI behavior may not align with others who want to use the child class specific key to do i18n lookups on a child class basis. However, this change will not effect existing implementations, it simply gives users the ability to customize the prefix however they want, if they want.