### PR TITLE
Validation against nil request when storing controller

### DIFF
--- a/lib/public_activity/utility/store_controller.rb
+++ b/lib/public_activity/utility/store_controller.rb
@@ -23,7 +23,10 @@ module PublicActivity
     end
 
     def store_controller_for_public_activity
-      PublicActivity.set_controller(self)
+      if request.present?
+        PublicActivity.set_controller(self)
+      end
+      
       yield
     ensure
       PublicActivity.set_controller(nil)


### PR DESCRIPTION
Created validation to guard against nil requests when storing a controller using PA, as brought up in issue #393