### PR TITLE
Prevent custom fields leaking between parent-child classes

### DIFF
--- a/lib/public_activity/roles/tracked.rb
+++ b/lib/public_activity/roles/tracked.rb
@@ -183,9 +183,10 @@ module PublicActivity
       end
 
       def assign_custom_fields(options)
-        options.except(*available_options).each do |k, v|
-          activity_custom_fields_global[k] = v
-        end
+        custom_fields = options.except(*available_options)
+        return if custom_fields.empty?
+
+        self.activity_custom_fields_global = activity_custom_fields_global.merge(custom_fields)
       end
     end
   end

--- a/test/test_tracking.rb
+++ b/test/test_tracking.rb
@@ -397,7 +397,7 @@ describe PublicActivity::Tracked do
     end
 
     it 'returns nil when no matching hook is present' do
-      assert_same nil, subject.get_hook(:nonexistent)
+      assert_nil subject.get_hook(:nonexistent)
     end
 
     it 'allows hooks to decide if activity should be created' do

--- a/test/test_tracking.rb
+++ b/test/test_tracking.rb
@@ -137,6 +137,28 @@ describe PublicActivity::Tracked do
     assert_equal a.class.activity_custom_fields_global, nonstandard: 'global'
   end
 
+  if PublicActivity.config.orm == :active_record
+    it 'does not leak subclass custom fields into parent class' do
+      parent = article(nonstandard: 'parent_value')
+      child = Class.new(parent) do
+        tracked nonstandard: 'child_value', extra: 'child_only'
+      end
+
+      assert_equal({ nonstandard: 'parent_value' }, parent.activity_custom_fields_global)
+      assert_equal({ nonstandard: 'child_value', extra: 'child_only' }, child.activity_custom_fields_global)
+    end
+
+    it 'does not leak custom fields between sibling subclasses' do
+      parent = article(nonstandard: 'parent_value')
+      sibling_a = Class.new(parent) { tracked a_field: 'a' }
+      sibling_b = Class.new(parent) { tracked b_field: 'b' }
+
+      refute sibling_a.activity_custom_fields_global.key?(:b_field)
+      refute sibling_b.activity_custom_fields_global.key?(:a_field)
+      assert_equal 'parent_value', parent.activity_custom_fields_global[:nonstandard]
+    end
+  end
+
   describe 'disabling functionality' do
     it 'allows for global disable' do
       PublicActivity.enabled = false

--- a/test/test_tracking.rb
+++ b/test/test_tracking.rb
@@ -156,10 +156,6 @@ describe PublicActivity::Tracked do
 
       refute sibling_a.activity_custom_fields_global.key?(:b_field)
       refute sibling_b.activity_custom_fields_global.key?(:a_field)
-      assert_equal 'parent_value', parent.activity_custom_fields_global[:nonstandard]
-      refute_same parent.activity_custom_fields_global, sibling_a.activity_custom_fields_global
-      refute_same parent.activity_custom_fields_global, sibling_b.activity_custom_fields_global
-      refute_same sibling_a.activity_custom_fields_global, sibling_b.activity_custom_fields_global
     end
   end
 

--- a/test/test_tracking.rb
+++ b/test/test_tracking.rb
@@ -146,6 +146,7 @@ describe PublicActivity::Tracked do
 
       assert_equal({ nonstandard: 'parent_value' }, parent.activity_custom_fields_global)
       assert_equal({ nonstandard: 'child_value', extra: 'child_only' }, child.activity_custom_fields_global)
+      refute_same parent.activity_custom_fields_global, child.activity_custom_fields_global
     end
 
     it 'does not leak custom fields between sibling subclasses' do
@@ -156,6 +157,9 @@ describe PublicActivity::Tracked do
       refute sibling_a.activity_custom_fields_global.key?(:b_field)
       refute sibling_b.activity_custom_fields_global.key?(:a_field)
       assert_equal 'parent_value', parent.activity_custom_fields_global[:nonstandard]
+      refute_same parent.activity_custom_fields_global, sibling_a.activity_custom_fields_global
+      refute_same parent.activity_custom_fields_global, sibling_b.activity_custom_fields_global
+      refute_same sibling_a.activity_custom_fields_global, sibling_b.activity_custom_fields_global
     end
   end
 


### PR DESCRIPTION
`activity_custom_fields_global` is declared via Rails' `class_attribute`.

With class_attribute, a subclass that reads the attribute (without assigning) inherits the same Hash object reference from the parent. So when `assign_custom_fields` mutates the hash via `[k] = v`, it mutates the parent class's hash too:


```rb
def assign_custom_fields(options)
  options.except(*available_options).each do |k, v|
    activity_custom_fields_global[k] = v   # mutates parent's hash
  end
end
```

So every `[]=` from a child's tracked call wrote directly into the parent's hash (and any sibling subclasses that hadn't yet written their own value).

## Example


```rb
class Parent < ActiveRecord::Base
  include PublicActivity::Model
  tracked owner: :author, foo: 'parent_value'
end
class Child < Parent
  tracked owner: :author, foo: 'child_value', bar: 'child_only'
end
Parent.activity_custom_fields_global
# => { foo: 'child_value', bar: 'child_only' }  # BUG: parent mutated
```